### PR TITLE
Make Stadia show PlayStation button prompts

### DIFF
--- a/ds5.js
+++ b/ds5.js
@@ -3,7 +3,7 @@ const setupDualSenseController = () => {
     const axis = 10;
 
     const emulatedDualSense = {
-        id: "DualSense 5 Controller",
+        id: "DualSense 5 Controller (STANDARD GAMEPAD Vendor: 054c Product: 09cc)",
         index: 0,
         connected: true,
         timestamp: 0,


### PR DESCRIPTION
By default, Stadia games show Microsoft Xbox button prompts. By using the vendor and product ID of a DualShock 4, Stadia games start showing PlayStation button prompts as expected.

Before:

![Schermafbeelding 2020-12-12 om 14 56 29](https://user-images.githubusercontent.com/2750434/101985770-4a061c80-3c8a-11eb-8127-8760774e4d63.png)

After:

![Schermafbeelding 2020-11-25 om 00 05 59](https://user-images.githubusercontent.com/2750434/101985525-e6c7ba80-3c88-11eb-9908-2404f5337a2e.png)